### PR TITLE
feat: GitHub Releases for Android & iOS mobile builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,224 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - mobile/**
+      - packages/shared/**
+      - .github/workflows/release.yml
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Target platform
+        required: true
+        default: android
+        type: choice
+        options:
+          - android
+          - ios
+          - both
+      version:
+        description: Version tag (auto-detected from app.json if left empty)
+        required: false
+        default: ''
+        type: string
+      prerelease:
+        description: Mark as pre-release?
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  # ── Build Android ──────────────────────────────────────────────────
+  android:
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.platform == 'android' || inputs.platform == 'both' }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          packages: 'platforms;android-34 build-tools;34.0.0'
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./mobile/app.json').expo.version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Install mobile dependencies
+        run: npm --prefix mobile ci
+
+      - name: Prebuild native Android project
+        run: npx expo prebuild --platform android --clean
+        working-directory: mobile
+
+      - name: Build Android AAB (Play Store bundle)
+        run: cd mobile/android && ./gradlew bundleRelease
+
+      - name: Build Android APK (direct install)
+        run: cd mobile/android && ./gradlew assembleRelease
+
+      - name: Upload Android artifacts
+        uses: actions/upload-artifact@v5
+        with:
+          name: android-release
+          path: |
+            mobile/android/app/build/outputs/bundle/release/*.aab
+            mobile/android/app/build/outputs/apk/release/*.apk
+          retention-days: 7
+
+  # ── Build iOS ──────────────────────────────────────────────────────
+  ios:
+    if: ${{ github.event_name == 'workflow_dispatch' && (inputs.platform == 'ios' || inputs.platform == 'both') }}
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: mobile/package-lock.json
+
+      - name: Install mobile dependencies
+        run: npm --prefix mobile ci
+
+      - name: Prebuild native iOS project
+        run: npx expo prebuild --platform ios --clean
+        working-directory: mobile
+
+      - name: Install CocoaPods
+        run: cd mobile/ios && pod install
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./mobile/app.json').expo.version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build iOS archive (unsigned, for simulator)
+        run: |
+          cd mobile/ios
+          xcodebuild \
+            -workspace Tilgjengelighetwms.xcworkspace \
+            -scheme Tilgjengelighetwms \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            build
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: ios-release
+          path: mobile/ios/build/*-iphonesimulator/*.app
+          retention-days: 7
+
+  # ── Create GitHub Release ──────────────────────────────────────────
+  release:
+    needs: [android, ios]
+    if: ${{ !cancelled() && (needs.android.result == 'success' || needs.android.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Determine version tag
+        id: tag
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            TAG="v${{ inputs.version }}"
+          else
+            VERSION=$(node -p "require('./mobile/app.json').expo.version")
+            TAG="v${VERSION}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Version tag: $TAG"
+
+      - name: Download Android artifacts
+        if: ${{ needs.android.result == 'success' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: android-release
+          path: artifacts/android
+
+      - name: Download iOS artifacts
+        if: ${{ needs.ios.result == 'success' }}
+        uses: actions/download-artifact@v5
+        with:
+          name: ios-release
+          path: artifacts/ios
+
+      - name: List artifacts
+        run: |
+          echo "=== Android ==="
+          find artifacts/android -type f -ls 2>/dev/null || echo "(none)"
+          echo "=== iOS ==="
+          find artifacts/ios -type f -ls 2>/dev/null || echo "(none)"
+
+      - name: Generate release notes
+        id: notes
+        run: |
+          {
+            echo "## 📱 Geonorge Tilgjengelighet — v${{ steps.tag.outputs.tag }}"
+            echo ""
+            echo "| Platform | File | Description |"
+            echo "|----------|------|-------------|"
+            find artifacts -type f | while read f; do
+              fname=$(basename "$f")
+              platform=$(echo "$f" | grep -q android && echo "Android" || echo "iOS")
+              ext="${fname##*.}"
+              desc=""
+              case "$ext" in
+                aab) desc="Play Store bundle" ;;
+                apk) desc="Direct install" ;;
+                *) desc="App" ;;
+              esac
+              echo "| $platform | $fname | $desc |"
+            done
+            echo ""
+            echo "### Installation"
+            echo "- **Android**: Download the APK and install directly, or use the AAB for Play Store"
+            echo "- **iOS**: Requires a Mac with Xcode to install on simulator or device"
+            echo ""
+            echo "> Built from commit \`$(git rev-parse --short HEAD)\`"
+          } > release-notes.md
+          cat release-notes.md
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: ${{ steps.tag.outputs.tag }}
+          body_path: release-notes.md
+          files: artifacts/**/*
+          prerelease: ${{ inputs.prerelease || github.event_name == 'push' }}
+          generate_release_notes: false
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -98,24 +98,23 @@ Detailed migration plan and architecture notes:
 
 - See `docs/expo-mobile-plan.md`
 
-### Mobile release automation (EAS)
+### Mobile apps — Releases and downloads
 
-This repo includes:
+Pre-built mobile apps are published as **GitHub Releases**. Testers can download the latest build directly from the [Releases page](../../releases).
 
-- `mobile/eas.json` for build/submit profiles
-- `.github/workflows/mobile-eas.yml` for manual EAS build and optional submit
+**Release workflow** (`.github/workflows/release.yml`):
+- **Android**: Builds automatically on every push to `main` (no token required). Produces **APK** (direct install) and **AAB** (Play Store bundle).
+- **iOS**: Triggered manually via `workflow_dispatch` (requires macOS runner). Produces an unsigned `.app` bundle for simulator testing. Signed IPA for device distribution requires an Apple Developer account configured with EAS (see below).
 
-Required repository secrets for the workflow:
+Each release includes:
+- The built APK/AAB (Android) and/or .app (iOS)
+- Auto-generated release notes with install instructions
+- Version tag derived from `mobile/app.json`
 
-- `EXPO_TOKEN`
-- iOS submit credentials (App Store Connect) configured in EAS
-- Android submit credentials (Google Play service account) configured in EAS
-
-Run the workflow from GitHub Actions with inputs:
-
-- `platform`: `ios`, `android`, or `all`
-- `profile`: `development`, `preview`, or `production`
-- `submit`: `true` to submit latest build to store channels
+**Cloud builds via EAS** (`.github/workflows/mobile-eas.yml`):
+- Requires `EXPO_TOKEN` repository secret
+- Supports signed iOS IPA and Play Store-ready AAB
+- Can also submit directly to App Store / Google Play
 
 ---
 


### PR DESCRIPTION
Adds automated GitHub Releases so testers can download the Android APK/iOS app directly from the [Releases page](../../releases).

## How it works

### Release workflow (`.github/workflows/release.yml`)

| Trigger | Platform | What's built |
|---------|----------|--------------|
| Push to `main` | Android | APK (direct install) + AAB (Play Store) |
| Manual (`workflow_dispatch`) | iOS | `.app` for simulator (unsigned) |
| Manual (`workflow_dispatch`) | Both | Android + iOS |

**No tokens required** — uses Continuous Native Generation (CNG):
1. `npx expo prebuild --platform android --clean` generates native project
2. `./gradlew assembleRelease` + `./gradlew bundleRelease` builds binaries
3. GitHub Release created via `softprops/action-gh-release@v2` with auto-generated notes

iOS requires a macOS GitHub Actions runner (triggered manually).

### Release contents
Each release includes:
- **`app-release.apk`** — install directly on Android devices
- **`app-release.aab`** — submit to Google Play Store
- Auto-generated release notes with version, platform, and install instructions
- Version tag derived from `mobile/app.json` (v1.0.0 format)

### README update
Documented the release workflow and download instructions in README.md.